### PR TITLE
Fix the issue #15

### DIFF
--- a/src/fragments/tooltip.jspf
+++ b/src/fragments/tooltip.jspf
@@ -199,6 +199,8 @@
 
             if (propertiesHtml.length > 0) {
                 tooltipProperties.html('<div class="smaller"><p>Properties:</p><ul>' + propertiesHtml + '</ul></div>');
+            } else {
+                tooltipProperties.html('')
             }
 
             var urlHtml = '';


### PR DESCRIPTION
Properties information in the tooltip is not displayed correctly when move from an element with properties to an element without properties #15