### PR TITLE
Improve zoom and scroll

### DIFF
--- a/src/js/structurizr-diagram.js
+++ b/src/js/structurizr-diagram.js
@@ -33,7 +33,7 @@ structurizr.ui.Diagram = function(id, diagramIsEditable, constructionCompleteCal
     const DEFAULT_MAX_ZOOM_SCALE = 2;
     var maxZoomScale = DEFAULT_MAX_ZOOM_SCALE;
     const zoomSteps = 40;
-    var zoomDelta = (maxZoomScale - minZoomScale) / zoomSteps;
+    var zoomFactor = Math.pow(maxZoomScale / minZoomScale, 1 / zoomSteps);
     var pageSizeDelta = 100;
 
     const thumbnailWidth = 400;
@@ -577,7 +577,7 @@ structurizr.ui.Diagram = function(id, diagramIsEditable, constructionCompleteCal
             if (embedded) {
                 self.zoomFitWidth();
                 minZoomScale = scale;
-                zoomDelta = (maxZoomScale - minZoomScale) / zoomSteps;
+                zoomFactor = Math.pow(maxZoomScale / minZoomScale, 1 / zoomSteps);
             } else {
                 self.zoomToWidthOrHeight();
             }
@@ -972,7 +972,7 @@ structurizr.ui.Diagram = function(id, diagramIsEditable, constructionCompleteCal
         if (embedded) {
             self.zoomFitWidth();
             minZoomScale = scale;
-            zoomDelta = (maxZoomScale - minZoomScale) / zoomSteps;
+            zoomFactor = Math.pow(maxZoomScale / minZoomScale, 1 / zoomSteps);
         } else {
             maxZoomScale = DEFAULT_MAX_ZOOM_SCALE;
             self.zoomToWidthOrHeight();
@@ -1632,7 +1632,7 @@ structurizr.ui.Diagram = function(id, diagramIsEditable, constructionCompleteCal
     function setZoomAndMargins() {
         minZoomScale = scale;
         maxZoomScale = DEFAULT_MAX_ZOOM_SCALE;
-        zoomDelta = (maxZoomScale - minZoomScale) / zoomSteps;
+        zoomFactor = Math.pow(maxZoomScale / minZoomScale, 1 / zoomSteps);
 
         var minimumWidth = minZoomScale * diagramWidth;
         var minimumHeight = minZoomScale * diagramHeight;
@@ -3915,12 +3915,14 @@ structurizr.ui.Diagram = function(id, diagramIsEditable, constructionCompleteCal
         this.scrollToPoint(centreX, centreY, clientTarget.x, clientTarget.y);
     };
 
-    this.zoomIn = function(evt) {
-        zoomToAndScroll(Math.min(scale + zoomDelta, maxZoomScale), evt);
+    this.zoomIn = function(evt, slow) {
+        const speedFactor = slow ? 0.5 : 1;
+        zoomToAndScroll(Math.min(scale * (zoomFactor ** speedFactor), maxZoomScale), evt);
     };
 
-    this.zoomOut = function(evt) {
-        zoomToAndScroll(Math.max(scale - zoomDelta, minZoomScale), evt);
+    this.zoomOut = function(evt, slow) {
+        const speedFactor = slow ? 0.5 : 1;
+        zoomToAndScroll(Math.max(scale / (zoomFactor ** speedFactor), minZoomScale), evt);
     };
 
     function zoomToAndScroll(zoomScale, evt) {
@@ -5872,8 +5874,8 @@ structurizr.ui.Diagram = function(id, diagramIsEditable, constructionCompleteCal
 
             var deltaX = (dragStartPosition.x - x);
             var deltaY = (dragStartPosition.y - y);
-            viewport.scrollLeft(scrollStartPosition.x + (deltaX * scale));
-            viewport.scrollTop(scrollStartPosition.y + (deltaY * scale));
+            viewport.scrollLeft(scrollStartPosition.x + (deltaX));
+            viewport.scrollTop(scrollStartPosition.y + (deltaY));
         }
     }
 

--- a/src/static.html
+++ b/src/static.html
@@ -218,9 +218,9 @@
         document.getElementById('diagram-viewport').addEventListener('wheel', function (event) {
                 if (event.ctrlKey === true) {
                     if (event.wheelDelta > 0) {
-                        structurizr.diagram.zoomIn(event);
+                        structurizr.diagram.zoomIn(event, true);
                     } else {
-                        structurizr.diagram.zoomOut(event);
+                        structurizr.diagram.zoomOut(event, true);
                     }
 
                     event.preventDefault();


### PR DESCRIPTION
Hi!

When trying out the new experimental "static" export of [structurizr/cli](https://github.com/structurizr/cli), I've stumbled across behavior of the UI that is not ideal, in my opinion. A quick check in [structurizr/lite](https://github.com/structurizr/lite) revealed this behavior there as well.

- When dragging a large diagram, the mouse position is not fixed to the diagram. Instead, the mouse moves more than the diagram does.
- Zooming is linear, which means that the first zoom step is perceived to be much bigger than the last steps.

This PR is my attempt at fixing these problems, by:
- removing an (IMO) unnecessary scale factor when dragging the diagram
- changing `zoomDelta` to `zoomFactor` and therefore using exponential zooming, which feels much more natural, in my opinion

I also slowed down zooming by mousewheel on the static page, because I felt, that the mousewheel could benefit from double the amount of zoom steps.

Please let me know, what you think, and if there's anything you'd like me to change!